### PR TITLE
Fix status checks name

### DIFF
--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -12,7 +12,7 @@ local customRuleset(name) =
     requires_pull_request: false,
     required_approving_review_count: null,
     required_status_checks+: [
-      "ci"
+      "CI status checks"
     ],
     requires_commit_signatures: false,
     requires_last_push_approval: false,


### PR DESCRIPTION
In https://github.com/eclipse-zenoh/.eclipsefdn/pull/5 I used the job name as a `StatusCheck` but that didn't ger recognized by GitHub. The docs state that "if a job has no name specified, use its id" so I suppose that means that if it does have a name, you _should_ use it instead of the id.