### PR TITLE
Add 'ci' repository

### DIFF
--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -530,9 +530,6 @@ orgs.newOrg('eclipse-zenoh') {
       description: "GitHub Actions and workflows used across eclipse-zenoh",
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
-      workflows+: {
-        default_workflow_permissions: "write",
-      },
     },
   ],
 }

--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -522,5 +522,17 @@ orgs.newOrg('eclipse-zenoh') {
         customRuleset("main"),
       ],
     },
+    orgs.newRepo('ci') {
+      allow_auto_merge: true,
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      description: "GitHub Actions and workflows used across eclipse-zenoh",
+      secret_scanning_push_protection: "disabled",
+      web_commit_signoff_required: false,
+      workflows+: {
+        default_workflow_permissions: "write",
+      },
+    },
   ],
 }


### PR DESCRIPTION
[Many](https://github.com/eclipse-zenoh/zenoh/blob/main/.github/workflows/enforce-linking-issues.yml) [workflows](https://github.com/eclipse-zenoh/zenoh/blob/main/.github/workflows/update-release-project.yml) [under](https://github.com/eclipse-zenoh/zenoh/blob/main/.github/workflows/sync-lockfiles.yml) eclipse-zenoh/zenoh either operate on a number of repositories or are used by a number of repositories. Conceptually, these workflows do not belong there. Having a dedicated repository is crucial for separation of concerns and grouping together all actions and workflows concerning cross-repository CI.

@netomi.