### PR TITLE
fix: Setup Read the Docs webhooks

### DIFF
--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -19,6 +19,13 @@ local customRuleset(name) =
     requires_review_thread_resolution: false,
   };
 
+local readTheDocsWebhookEvents = [
+  "create",
+  "delete",
+  "push",
+  "pull_request"
+];
+
 orgs.newOrg('eclipse-zenoh') {
   settings+: {
     dependabot_security_updates_enabled_for_new_repositories: false,
@@ -213,12 +220,7 @@ orgs.newOrg('eclipse-zenoh') {
       webhooks: [
         orgs.newRepoWebhook('https://readthedocs.org/api/v2/webhook/zenoh-c/263729/') {
           content_type: "json",
-          events+: [
-            "create",
-            "delete",
-            "push",
-            "pull_request"
-          ],
+          events+: readTheDocsWebhookEvents
         },
       ],
       rulesets: [
@@ -236,6 +238,12 @@ orgs.newOrg('eclipse-zenoh') {
       workflows+: {
         default_workflow_permissions: "write",
       },
+      webhooks: [
+        orgs.newRepoWebhook('https://readthedocs.org/api/v2/webhook/zenoh-cpp/263743/') {
+          content_type: "json",
+          events+: readTheDocsWebhookEvents
+        },
+      ],
     },
     orgs.newRepo('zenoh-csharp') {
       allow_auto_merge: true,
@@ -387,6 +395,12 @@ orgs.newOrg('eclipse-zenoh') {
       workflows+: {
         default_workflow_permissions: "write",
       },
+      webhooks: [
+        orgs.newRepoWebhook('https://readthedocs.org/api/v2/webhook/zenoh-pico/263750/') {
+          content_type: "json",
+          events+: readTheDocsWebhookEvents
+        },
+      ],
     },
     orgs.newRepo('zenoh-plugin-dds') {
       allow_auto_merge: true,
@@ -513,10 +527,9 @@ orgs.newOrg('eclipse-zenoh') {
         default_workflow_permissions: "write",
       },
       webhooks: [
-        orgs.newRepoWebhook('https://readthedocs.org/api/v2/webhook/zenoh-python/135566/') {
-          events+: [
-            "push"
-          ],
+        orgs.newRepoWebhook('https://readthedocs.org/api/v2/webhook/zenoh-python/263749/') {
+          content_type: "json",
+          events+: readTheDocsWebhookEvents
         },
       ],
       rulesets: [

--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -220,7 +220,8 @@ orgs.newOrg('eclipse-zenoh') {
       webhooks: [
         orgs.newRepoWebhook('https://readthedocs.org/api/v2/webhook/zenoh-c/263729/') {
           content_type: "json",
-          events+: readTheDocsWebhookEvents
+          events+: readTheDocsWebhookEvents,
+          secret: "pass:bots/iot.zenoh/readthedocs.org/zenoh-c-webhook-secret"
         },
       ],
       rulesets: [
@@ -241,7 +242,8 @@ orgs.newOrg('eclipse-zenoh') {
       webhooks: [
         orgs.newRepoWebhook('https://readthedocs.org/api/v2/webhook/zenoh-cpp/263743/') {
           content_type: "json",
-          events+: readTheDocsWebhookEvents
+          events+: readTheDocsWebhookEvents,
+          secret: "pass:bots/iot.zenoh/readthedocs.org/zenoh-cpp-webhook-secret"
         },
       ],
     },
@@ -398,7 +400,8 @@ orgs.newOrg('eclipse-zenoh') {
       webhooks: [
         orgs.newRepoWebhook('https://readthedocs.org/api/v2/webhook/zenoh-pico/263750/') {
           content_type: "json",
-          events+: readTheDocsWebhookEvents
+          events+: readTheDocsWebhookEvents,
+          secret: "pass:bots/iot.zenoh/readthedocs.org/zenoh-pico-webhook-secret"
         },
       ],
     },
@@ -529,7 +532,8 @@ orgs.newOrg('eclipse-zenoh') {
       webhooks: [
         orgs.newRepoWebhook('https://readthedocs.org/api/v2/webhook/zenoh-python/263749/') {
           content_type: "json",
-          events+: readTheDocsWebhookEvents
+          events+: readTheDocsWebhookEvents,
+          secret: "pass:bots/iot.zenoh/readthedocs.org/zenoh-python-webhook-secret"
         },
       ],
       rulesets: [

--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -211,7 +211,7 @@ orgs.newOrg('eclipse-zenoh') {
         default_workflow_permissions: "write",
       },
       webhooks: [
-        orgs.newRepoWebhook('https://readthedocs.org/api/v2/webhook/zenoh-c/135565/') {
+        orgs.newRepoWebhook('https://readthedocs.org/api/v2/webhook/zenoh-c/263729/') {
           content_type: "json",
           events+: [
             "create",

--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -216,7 +216,8 @@ orgs.newOrg('eclipse-zenoh') {
           events+: [
             "create",
             "delete",
-            "push"
+            "push",
+            "pull_request"
           ],
         },
       ],


### PR DESCRIPTION
The zenoh-c Read the Docs webook has been failing for a while with the following error:

```json
{
  "detail": "Payload not valid, invalid or missing signature"
}
```

This can apparently be fixed by regenerating the webhook URL and secret (or using the "resync webhook" feature in Read the Docs, but that would require the actor to have admin permissions on zenoh-c?).

However, there is the issue of supplying the secret, which wasn't there to beging with (maybe that's another reason why the hook was failing?). We would have to _somehow_ exchange the secret through some means other than this pull request.

Moreover, we're looking to add `pull_request` to the webhook events as explained [here](https://docs.readthedocs.io/en/stable/guides/setup/git-repo-manual.html#manual-integration-setup) to include documentation builds in CI.