### PR TITLE
feat: Add zenoh-ts repository

### DIFF
--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -547,5 +547,19 @@ orgs.newOrg('eclipse-zenoh') {
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
     },
+    orgs.newRepo('zenoh-ts') {
+      allow_auto_merge: true,
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      description: "TypeScript Interface to the Zenoh Protocol.",
+      homepage: "http://zenoh.io",
+      secret_scanning_push_protection: "disabled",
+      topics+: [
+        "typescript",
+        "zenoh"
+      ],
+      web_commit_signoff_required: false,
+    },
   ],
 }


### PR DESCRIPTION
This repository will host the Zenoh TypeScript bindings.