### PR TITLE
wip: Rename default eclipse-zenoh/zenoh branch to `main_old`

### DIFF
--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -120,6 +120,7 @@ orgs.newOrg('eclipse-zenoh') {
       rulesets: [
         customRuleset("main"),
       ],
+      default_branch: "main_old"
     },
     orgs.newRepo('zenoh-backend-filesystem') {
       allow_auto_merge: true,


### PR DESCRIPTION
After a mistaken [merge commit](https://github.com/eclipse-zenoh/zenoh/commit/e4840216110a66c7b5219e6fb5674ceb9880f205) on eclipse-zenoh/zenoh's `main` branch. We're trying to restore the `main` branch's history to what it was before said commit. The new fixed branch is called `main_restore`. We'll that in the following way:

1. Rename the default branch to `main_old`
2. Push a copy of `main_restore` called `main`
3. Rename the default branch to `main`

This pull request does step (1).