### PR TITLE
revert: Rename default eclipse-zenoh/zenoh branch to `main_old`

### DIFF
--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -120,7 +120,6 @@ orgs.newOrg('eclipse-zenoh') {
       rulesets: [
         customRuleset("main"),
       ],
-      default_branch: "main_old"
     },
     orgs.newRepo('zenoh-backend-filesystem') {
       allow_auto_merge: true,


### PR DESCRIPTION
This reverts commit 4ce6bf3b2b895fcd98b35ef18b03e34de86a60f9.

See #10.