### PR TITLE
feat: Add `.github` repository

### DIFF
--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -527,5 +527,14 @@ orgs.newOrg('eclipse-zenoh') {
       ],
       web_commit_signoff_required: false,
     },
+    orgs.newRepo('.github') {
+      allow_auto_merge: true,
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      description: "A repository for default files (community health files, issue templates, etc)",
+      secret_scanning_push_protection: "disabled",
+      web_commit_signoff_required: false,
+    },
   ],
 }


### PR DESCRIPTION
We're planning to use this to store community health files such as `SECURITY` and `CODE_OF_CONDUCT` in a single source of truth. An example would be the rust-lang organization where `SECURITY.md` is stored in https://github.com/rust-lang/.github and is accessible from https://github.com/rust-lang/rust?tab=security-ov-file.

@netomi What do you think of such a setup?