### PR TITLE
Add `zenoh-dissector` repository

### DIFF
--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -534,5 +534,18 @@ orgs.newOrg('eclipse-zenoh') {
       description: 'A repository for default files (community health files, issue templates, etc)',
       web_commit_signoff_required: false,
     },
+    orgs.newRepo('zenoh-dissector') {
+      allow_auto_merge: true,
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      description: 'Wireshark dissector for the Zenoh protocol',
+      homepage: 'http://zenoh.io',
+      topics+: [
+        'wireshark',
+        'zenoh',
+      ],
+      web_commit_signoff_required: false,
+    },
   ],
 }

--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -539,6 +539,7 @@ orgs.newOrg('eclipse-zenoh') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
       description: 'Wireshark dissector for the Zenoh protocol',
       homepage: 'http://zenoh.io',
       topics+: [


### PR DESCRIPTION
This is in order to contribute https://github.com/ZettaScaleLabs/zenoh-dissector/ to eclipse-zenoh.