### PR TITLE
Add gpg key_id and apply naming convention

### DIFF
--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -49,6 +49,9 @@ orgs.newOrg('eclipse-zenoh') {
     orgs.newOrgSecret('PYPI_ORG_TOKEN') {
       value: 'pass:bots/iot.zenoh/pypi.org/api-token',
     },
+    orgs.newOrgSecret('ORG_GPG_KEY_ID') {
+      value: 'pass:bots/iot.zenoh/gpg/key_id',
+    },
     orgs.newOrgSecret('ORG_GPG_PASSPHRASE') {
       value: 'pass:bots/iot.zenoh/gpg/passphrase',
     },

--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -49,10 +49,10 @@ orgs.newOrg('eclipse-zenoh') {
     orgs.newOrgSecret('PYPI_ORG_TOKEN') {
       value: 'pass:bots/iot.zenoh/pypi.org/api-token',
     },
-    orgs.newOrgSecret('SSH_PASSPHRASE') {
+    orgs.newOrgSecret('ORG_GPG_PASSPHRASE') {
       value: 'pass:bots/iot.zenoh/gpg/passphrase',
     },
-    orgs.newOrgSecret('SSH_PRIVATE_KEY') {
+    orgs.newOrgSecret('ORG_GPG_PRIVATE_KEY') {
       value: 'pass:bots/iot.zenoh/gpg/secret-subkeys.asc',
     },
     orgs.newOrgSecret('ORG_OSSRH_PASSWORD') {


### PR DESCRIPTION
Related to https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5255

This issue have an impact on the following projects:
* [eclipse-zenoh/ci](https://github.com/eclipse-zenoh/ci)
* [eclipse-zenoh/zenoh-cpp](https://github.com/eclipse-zenoh/zenoh-cpp)
* [eclipse-zenoh/zenoh-pico](https://github.com/eclipse-zenoh/zenoh-pico)

Please update their workflow according to the renaming. 