### PR TITLE
Add Zenoh-ts permission workflow write

### DIFF
--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -537,6 +537,9 @@ orgs.newOrg('eclipse-zenoh') {
         'zenoh',
       ],
       web_commit_signoff_required: false,
+      workflows+: {
+        default_workflow_permissions: 'write',
+      },
     },
     orgs.newRepo('.github') {
       allow_auto_merge: true,


### PR DESCRIPTION
Adds the permission for a workflow to Write to the repository. 

Reason: Release workflow blocked from pushing to Repo.
https://github.com/eclipse-zenoh/zenoh-ts/actions/runs/11958459754/job/33338018003