### PR TITLE
Enable GitHub Pages for `zenoh-ts`

### DIFF
--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -549,6 +549,7 @@ orgs.newOrg('eclipse-zenoh') {
       rulesets: [
         customRuleset('main'),
       ],
+      gh_pages_build_type: 'workflow',
     },
     orgs.newRepo('.github') {
       allow_auto_merge: true,


### PR DESCRIPTION
This sets `gh_pages_build_type` which is [currently `disabled`](https://otterdog.eclipse.org/projects/iot.zenoh/repos/zenoh-ts#settings).