### PR TITLE
fix: update zenoh-dissector config

### DIFF
--- a/otterdog/eclipse-zenoh.jsonnet
+++ b/otterdog/eclipse-zenoh.jsonnet
@@ -577,6 +577,12 @@ orgs.newOrg('iot.zenoh', 'eclipse-zenoh') {
         'zenoh',
       ],
       web_commit_signoff_required: false,
+      workflows+: {
+        default_workflow_permissions: 'write',
+      },
+      rulesets: [
+        customRuleset('main'),
+      ],
     },
   ],
 }


### PR DESCRIPTION
- add branch protection rule
- default workflow permission to write